### PR TITLE
Autotools and template fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 pkgdata_DATA = README COPYING ChangeLog NEWS AUTHORS
-SUBDIRS = adept include benchmark test
+SUBDIRS = adept include benchmark
 # The test/ directory does not use automake so we need to specify the
 # files that will be included in the distribution
 EXTRA_DIST = test/Makefile test/README test/*.cpp test/*.h test/run_tests.sh \

--- a/adept/Makefile.am
+++ b/adept/Makefile.am
@@ -5,4 +5,4 @@ libadept_la_SOURCES = Array.cpp Stack.cpp StackStorageOrig.cpp \
 	vector_utilities.cpp
 #cpplapack.cpp
 
-libadept_la_CPPFLAGS = -I../include
+libadept_la_CPPFLAGS = -I@top_srcdir@/include

--- a/benchmark/Makefile.am
+++ b/benchmark/Makefile.am
@@ -3,14 +3,14 @@ autodiff_benchmark_SOURCES = autodiff_benchmark.cpp \
 	differentiator.h advection_schemes.h \
 	advection_schemes_AD.h advection_schemes_K.h nx.h
 
-autodiff_benchmark_CPPFLAGS = -I../include
-autodiff_benchmark_LDFLAGS = -static -no-install -L../adept/.libs
+autodiff_benchmark_CPPFLAGS = -I@top_srcdir@/include
+autodiff_benchmark_LDFLAGS = -static -no-install -L@top_srcdir@/adept/.libs
 autodiff_benchmark_LDADD = -ladept
 
 animate_SOURCES = animate.cpp
-animate_CPPFLAGS = -I../include
+animate_CPPFLAGS = -I@top_srcdir@/include
 
 matrix_benchmark_SOURCES = matrix_benchmark.cpp
-matrix_benchmark_CPPFLAGS = -I../include
-matrix_benchmark_LDFLAGS = -static -no-install -L../adept/.libs
+matrix_benchmark_CPPFLAGS = -I@top_srcdir@/include
+matrix_benchmark_LDFLAGS = -static -no-install -L@top_srcdir@/adept/.libs
 matrix_benchmark_LDADD = -ladept

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -17,6 +17,6 @@ pkginclude_HEADERS = adept/Active.h adept/ActiveReference.h adept/Allocator.h \
 
 EXTRA_DIST = Timer.h create_adept_source_header adept_source.h
 
-adept_source.h: ../adept/*.h ../adept/*.cpp
-	./create_adept_source_header
+adept_source.h: @top_srcdir@/adept/*.h @top_srcdir@/adept/*.cpp
+	@srcdir@/create_adept_source_header
 all-local: adept_source.h

--- a/include/adept/ArrayWrapper.h
+++ b/include/adept/ArrayWrapper.h
@@ -51,7 +51,7 @@ namespace adept {
       
       template <int n>
       int alignment_offset_() const {
-	return array.alignment_offset_<n>();
+	return array.template alignment_offset_<n>();
       }
       
       Type value_with_len_(const Index& j, const Index& len) const {
@@ -61,7 +61,7 @@ namespace adept {
       // Optimize by storing the offset of the fastest-varying dimension?
       template <int MyArrayNum, int NArrays>
       void advance_location_(ExpressionSize<NArrays>& loc) const {
-	array.advance_location_<MyArrayNum>(loc);
+	array.template advance_location_<MyArrayNum>(loc);
       }
       
       template <int MyArrayNum, int NArrays>
@@ -89,20 +89,20 @@ namespace adept {
       template <int MyArrayNum, int NArrays>
       void set_location_(const ExpressionSize<Rank>& i, 
 			 ExpressionSize<NArrays>& index) const {
-	array.set_location_<MyArrayNum>(i, index);
+	array.template set_location_<MyArrayNum>(i, index);
       }
 
       template <int MyArrayNum, int MyScratchNum, int NArrays, int NScratch>
       void calc_gradient_(Stack& stack, const ExpressionSize<NArrays>& loc,
 			  const ScratchVector<NScratch>& scratch) const {
-	array.calc_gradient_<MyArrayNum,MyScratchNum>(stack, loc, scratch);
+	array.template calc_gradient_<MyArrayNum,MyScratchNum>(stack, loc, scratch);
       }
 
       template <int MyArrayNum, int MyScratchNum, int NArrays, int NScratch, typename MyType>
       void calc_gradient_(Stack& stack, const ExpressionSize<NArrays>& loc,
 			  const ScratchVector<NScratch>& scratch,
 			  MyType multiplier) const {
-	array.calc_gradient_<MyArrayNum,MyScratchNum>(stack, loc, scratch, multiplier);
+	array.template calc_gradient_<MyArrayNum,MyScratchNum>(stack, loc, scratch, multiplier);
       }
          
       

--- a/include/adept/BinaryOperation.h
+++ b/include/adept/BinaryOperation.h
@@ -146,8 +146,8 @@ namespace adept {
       }
       template <int n>
       int alignment_offset_() const {
-	int l = left.alignment_offset_<n>();
-	int r = right.alignment_offset_<n>();
+	int l = left.template alignment_offset_<n>();
+	int r = right.template alignment_offset_<n>();
 	if (l == r) {
 	  return l;
 	}
@@ -168,14 +168,14 @@ namespace adept {
 
       template <int MyArrayNum, int NArrays>
       void advance_location_(ExpressionSize<NArrays>& loc) const {
-	left .advance_location_<MyArrayNum>(loc);
-	right.advance_location_<MyArrayNum+L::n_arrays>(loc);
+	left.template advance_location_<MyArrayNum>(loc);
+	right.template advance_location_<MyArrayNum+L::n_arrays>(loc);
       }
 
       template <int MyArrayNum, int NArrays>
       Type value_at_location_(const ExpressionSize<NArrays>& loc) const {
-	return operation(left .value_at_location_<MyArrayNum>(loc),
-			 right.value_at_location_<MyArrayNum+L::n_arrays>(loc));
+	return operation(left.template value_at_location_<MyArrayNum>(loc),
+			 right.template value_at_location_<MyArrayNum+L::n_arrays>(loc));
       }
       template <int MyArrayNum, int NArrays>
       Packet<Type> packet_at_location_(const ExpressionSize<NArrays>& loc) const {
@@ -187,8 +187,8 @@ namespace adept {
 				      right.packet_at_location_<MyArrayNum+L::n_arrays>(loc))
 		  << "\n";
 	*/
-	return operation(left .packet_at_location_<MyArrayNum>(loc),
-			 right.packet_at_location_<MyArrayNum+L::n_arrays>(loc));
+	return operation(left.template packet_at_location_<MyArrayNum>(loc),
+			 right.template packet_at_location_<MyArrayNum+L::n_arrays>(loc));
       }
 
 
@@ -215,8 +215,8 @@ namespace adept {
       my_value_at_location_store_(const ExpressionSize<NArrays>& loc,
 				       ScratchVector<NScratch>& scratch) const {
 	return scratch[MyScratchNum] 
-	  = operation(left .value_at_location_store_<MyArrayNum,MyScratchNum+n_local_scratch>(loc, scratch),
-		      right.value_at_location_store_<MyArrayNum+L::n_arrays,
+	  = operation(left.template value_at_location_store_<MyArrayNum,MyScratchNum+n_local_scratch>(loc, scratch),
+		      right.template value_at_location_store_<MyArrayNum+L::n_arrays,
 						     MyScratchNum+L::n_scratch+n_local_scratch>(loc, scratch));
       }
       // In differentiating "a/b", it helps to store "1/b";
@@ -227,8 +227,8 @@ namespace adept {
       my_value_at_location_store_(const ExpressionSize<NArrays>& loc,
 				       ScratchVector<NScratch>& scratch) const {
 	return scratch[MyScratchNum] 
-	  = Op::operation_store(left .value_at_location_store_<MyArrayNum,MyScratchNum+n_local_scratch>(loc, scratch),
-			    right.value_at_location_store_<MyArrayNum+L::n_arrays,
+	  = Op::operation_store(left.template value_at_location_store_<MyArrayNum,MyScratchNum+n_local_scratch>(loc, scratch),
+			    right.template value_at_location_store_<MyArrayNum+L::n_arrays,
 			    MyScratchNum+L::n_scratch+n_local_scratch>(loc, scratch),
 			    scratch[MyScratchNum+1]);
       }
@@ -250,8 +250,8 @@ namespace adept {
 	return operation(left .value_at_location_<MyArrayNum>(loc),
 			 right.value_at_location_<MyArrayNum+L::n_arrays>(loc));
 	*/
-	return operation(left .value_at_location_store_<MyArrayNum,MyScratchNum+n_local_scratch>(loc, scratch),
-			 right.value_at_location_store_<MyArrayNum+L::n_arrays,
+	return operation(left.template value_at_location_store_<MyArrayNum,MyScratchNum+n_local_scratch>(loc, scratch),
+			 right.template value_at_location_store_<MyArrayNum+L::n_arrays,
 			 MyScratchNum+L::n_scratch+n_local_scratch>(loc, scratch));
       }
 
@@ -259,8 +259,8 @@ namespace adept {
       typename enable_if<StoreResult==0, Type>::type
       my_value_stored_(const ExpressionSize<NArrays>& loc,
 		       const ScratchVector<NScratch>& scratch) const {
-	return operation(left .value_at_location_<MyArrayNum>(loc),
-			 right.value_at_location_<MyArrayNum+L::n_arrays>(loc));
+	return operation(left.template value_at_location_<MyArrayNum>(loc),
+			 right.template value_at_location_<MyArrayNum+L::n_arrays>(loc));
       }
     
 
@@ -269,8 +269,8 @@ namespace adept {
       template <int MyArrayNum, int Rank, int NArrays>
       void set_location_(const ExpressionSize<Rank>& i, 
 			 ExpressionSize<NArrays>& index) const {
-	left. set_location_<MyArrayNum>(i, index);
-	right.set_location_<MyArrayNum+L::n_arrays>(i, index);
+	left.template set_location_<MyArrayNum>(i, index);
+	right.template set_location_<MyArrayNum+L::n_arrays>(i, index);
       }
 
 
@@ -405,7 +405,7 @@ namespace adept {
 	return right.all_arrays_contiguous_(); 
       }
       template <int n>
-      int alignment_offset_() const { return right.alignment_offset_<n>(); }
+      int alignment_offset_() const { return right.template alignment_offset_<n>(); }
 
       Type value_with_len_(const Index& j, const Index& len) const {
 	return operation(left.value, right.value_with_len(j,len));
@@ -413,17 +413,17 @@ namespace adept {
 
       template <int MyArrayNum, int NArrays>
       void advance_location_(ExpressionSize<NArrays>& loc) const {
-	right.advance_location_<MyArrayNum>(loc);
+	right.template advance_location_<MyArrayNum>(loc);
       }
 
       template <int MyArrayNum, int NArrays>
       Type value_at_location_(const ExpressionSize<NArrays>& loc) const {
-	return operation(left.value, right.value_at_location_<MyArrayNum>(loc));
+	return operation(left.template value, right.template value_at_location_<MyArrayNum>(loc));
       }
       template <int MyArrayNum, int NArrays>
       Packet<Type> packet_at_location_(const ExpressionSize<NArrays>& loc) const {
 	return operation(left, 
-			 right.packet_at_location_<MyArrayNum>(loc));
+			 right.template packet_at_location_<MyArrayNum>(loc));
       }
 
       template <int MyArrayNum, int MyScratchNum, int NArrays, int NScratch>
@@ -445,7 +445,7 @@ namespace adept {
       my_value_at_location_store_(const ExpressionSize<NArrays>& loc,
 				       ScratchVector<NScratch>& scratch) const {
 	return scratch[MyScratchNum] = operation(left.value,
-		      right.value_at_location_store_<MyArrayNum, MyScratchNum+n_local_scratch>(loc, scratch));
+		      right.template value_at_location_store_<MyArrayNum, MyScratchNum+n_local_scratch>(loc, scratch));
       }
       template <int StoreResult, int MyArrayNum, int MyScratchNum, 
 		int NArrays, int NScratch>
@@ -486,7 +486,7 @@ namespace adept {
       template <int MyArrayNum, int Rank, int NArrays>
       void set_location_(const ExpressionSize<Rank>& i, 
 			 ExpressionSize<NArrays>& index) const {
-	right.set_location_<MyArrayNum>(i, index);
+	right.template set_location_<MyArrayNum>(i, index);
       }
 
 
@@ -593,7 +593,7 @@ namespace adept {
 	return left.all_arrays_contiguous_(); 
       }
       template <int n>
-      int alignment_offset_() const { return left.alignment_offset_<n>(); }
+      int alignment_offset_() const { return left.template alignment_offset_<n>(); }
 
       Type value_with_len_(const Index& j, const Index& len) const {
 	return operation(left.value_with_len(j,len), right.value);
@@ -601,12 +601,12 @@ namespace adept {
 
       template <int MyArrayNum, int NArrays>
       void advance_location_(ExpressionSize<NArrays>& loc) const {
-	left.advance_location_<MyArrayNum>(loc);
+	left.template advance_location_<MyArrayNum>(loc);
       }
 
       template <int MyArrayNum, int NArrays>
       Type value_at_location_(const ExpressionSize<NArrays>& loc) const {
-	return operation(left.value_at_location_<MyArrayNum>(loc), right.value);
+	return operation(left.template value_at_location_<MyArrayNum>(loc), right.value);
       }
       template <int MyArrayNum, int NArrays>
       Packet<Type> packet_at_location_(const ExpressionSize<NArrays>& loc) const {
@@ -641,7 +641,7 @@ namespace adept {
       my_value_at_location_store_(const ExpressionSize<NArrays>& loc,
 				       ScratchVector<NScratch>& scratch) const {
 	return scratch[MyScratchNum] = operation(
-	   left.value_at_location_store_<MyArrayNum, MyScratchNum+n_local_scratch>(loc, scratch), right.value);
+	   left.template value_at_location_store_<MyArrayNum, MyScratchNum+n_local_scratch>(loc, scratch), right.value);
       }
 
       template <int StoreResult, int MyArrayNum, int MyScratchNum, int NArrays, int NScratch>
@@ -673,7 +673,7 @@ namespace adept {
       template <int MyArrayNum, int Rank, int NArrays>
       void set_location_(const ExpressionSize<Rank>& i, 
 			 ExpressionSize<NArrays>& index) const {
-	left.set_location_<MyArrayNum>(i, index);
+	left.template set_location_<MyArrayNum>(i, index);
       }
 
 

--- a/include/adept/Expression.h
+++ b/include/adept/Expression.h
@@ -185,7 +185,7 @@ namespace adept {
     // the offset of the data in any arrays in the expression, or -1 if
     // there is a clash in offsets.
     int alignment_offset() const {
-      int val = cast().alignment_offset_<Packet<Type>::size>();
+      int val = cast().template alignment_offset_<Packet<Type>::size>();
       if (val < Packet<Type>::size) {
 	return val;
       }

--- a/include/adept/UnaryOperation.h
+++ b/include/adept/UnaryOperation.h
@@ -73,7 +73,7 @@ namespace adept {
 	return arg.all_arrays_contiguous_();
       }
       template <int n>
-      int alignment_offset_() const { return arg.alignment_offset_<n>(); }
+      int alignment_offset_() const { return arg.template alignment_offset_<n>(); }
 
       /*
       template <int Rank>
@@ -99,19 +99,19 @@ namespace adept {
       
       template <int MyArrayNum, int NArrays>
       void advance_location_(ExpressionSize<NArrays>& loc) const {
-	arg.advance_location_<MyArrayNum>(loc);
+	arg.template advance_location_<MyArrayNum>(loc);
       }
 
       template <int MyArrayNum, int NArrays>
       Type value_at_location_(const ExpressionSize<NArrays>& loc) const {
-	return operation(arg.value_at_location_<MyArrayNum>(loc));
+	return operation(arg.template value_at_location_<MyArrayNum>(loc));
       }
 
       template <int MyArrayNum, int MyScratchNum, int NArrays, int NScratch>
       Type value_at_location_store_(const ExpressionSize<NArrays>& loc,
 				    ScratchVector<NScratch>& scratch) const {
 	return scratch[MyScratchNum] 
-	  = operation(arg.value_at_location_store_<MyArrayNum,MyScratchNum+1>(loc, scratch));
+	  = operation(arg.template value_at_location_store_<MyArrayNum,MyScratchNum+1>(loc, scratch));
       }
 
       template <int MyArrayNum, int MyScratchNum, int NArrays, int NScratch>
@@ -136,14 +136,14 @@ namespace adept {
 			  const ScratchVector<NScratch>& scratch,
 			  MyType multiplier) const {
 	arg.template calc_gradient_<MyArrayNum, MyScratchNum+1>(stack, loc, scratch,
-		multiplier*derivative(arg.value_stored_<MyArrayNum,MyScratchNum+1>(loc, scratch), 
+		multiplier*derivative(arg.template value_stored_<MyArrayNum,MyScratchNum+1>(loc, scratch), 
 				      scratch[MyScratchNum]));
       }
 
       template <int MyArrayNum, int Rank, int NArrays>
       void set_location_(const ExpressionSize<Rank>& i, 
 			 ExpressionSize<NArrays>& index) const {
-	arg.set_location_<MyArrayNum>(i, index);
+	arg.template set_location_<MyArrayNum>(i, index);
       }
 
     }; // End UnaryOperation type
@@ -422,7 +422,7 @@ namespace adept {
 	return arg.all_arrays_contiguous_(); 
       }
       template <int n>
-      int alignment_offset_() const { return arg.alignment_offset_<n>(); }
+      int alignment_offset_() const { return arg.template alignment_offset_<n>(); }
 
       template <int Rank>
       Type value_with_len_(Index i, Index len) const {

--- a/include/adept/noalias.h
+++ b/include/adept/noalias.h
@@ -66,22 +66,22 @@ namespace adept {
       
       template <int MyArrayNum, int NArrays>
       void advance_location_(ExpressionSize<NArrays>& loc) const {
-	arg.advance_location_<MyArrayNum>(loc);
+	arg.template advance_location_<MyArrayNum>(loc);
       }
 
       template <int MyArrayNum, int NArrays>
       Type value_at_location_(const ExpressionSize<NArrays>& loc) const {
-	return arg.value_at_location_<MyArrayNum>(loc);
+	return arg.template value_at_location_<MyArrayNum>(loc);
       }
       template <int MyArrayNum, int NArrays>
       Packet<Type> packet_at_location_(const ExpressionSize<NArrays>& loc) const {
-	return arg.packet_at_location_<MyArrayNum>(loc);
+	return arg.template packet_at_location_<MyArrayNum>(loc);
       }
 
       template <int MyArrayNum, int MyScratchNum, int NArrays, int NScratch>
       Type value_at_location_store_(const ExpressionSize<NArrays>& loc,
 				    ScratchVector<NScratch>& scratch) const {
-	return arg.value_at_location_store_<MyArrayNum,MyScratchNum>(loc, 
+	return arg.template value_at_location_store_<MyArrayNum,MyScratchNum>(loc, 
 								     scratch);
       }
 
@@ -113,7 +113,7 @@ namespace adept {
       template <int MyArrayNum, int Rank, int NArrays>
       void set_location_(const ExpressionSize<Rank>& i, 
 			 ExpressionSize<NArrays>& index) const {
-	arg.set_location_<MyArrayNum>(i, index);
+	arg.template set_location_<MyArrayNum>(i, index);
       }
 
     }; // End struct NoAlias

--- a/include/adept/noalias.h
+++ b/include/adept/noalias.h
@@ -55,7 +55,9 @@ namespace adept {
 	return arg.all_arrays_contiguous_(); 
       }
       template <int n>
-      int alignment_offset_() const { return arg.alignment_offset_<n>(); }
+      int alignment_offset_() const { 
+        return arg.template alignment_offset_<n>();
+      }
 
       template <int Rank>
       Type value_with_len_(Index i, Index len) const {

--- a/include/adept/outer_product.h
+++ b/include/adept/outer_product.h
@@ -76,7 +76,7 @@ namespace adept {
 
       template <int n>
       int alignment_offset_() const {
-	return right.alignment_offset_<n>();
+	return right.template alignment_offset_<n>();
       }
 
       // Do not implement value_with_len_

--- a/include/adept/spread.h
+++ b/include/adept/spread.h
@@ -77,7 +77,7 @@ namespace adept {
 
       template <int N>
       int alignment_offset_() const {
-	return array.alignment_offset_<N>();
+	return array.template alignment_offset_<N>();
       }
 
       // Do not implement value_with_len_


### PR DESCRIPTION
I encountered the template issues with gcc v7.2.0.  I'd also suggest that the `test` directory be added to the autotools build system, so that `make check` doesn't rely on the build occurring at the  top level, but I didn't include those in this PR.