### PR TITLE
Add cmake build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,11 @@ compiler:
 before_install:
   - sudo apt-get install gfortran -y
   - type gfortran
-install: autoreconf -i && ./configure && make -j8 
-script: 
-  - make check -j8
-  - cat test/test_results.txt
+jobs:
+  include:
+    - stage: build-and-test
+      install: autoreconf -i && ./configure && make -j8 
+      script: make check -j8 && cat test/test_results.txt
+    - 
+      install: mkdir build && cd build && cmake -DCMAKE_PREFIX_PATH=$PWD .. && make -j8 install
+      script: ./test.sh

--- a/Adept2Config.cmake
+++ b/Adept2Config.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/adept.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(Adept2)
 
 set(CMAKE_CXX_STANDARD 14)
 
+include(CTest)
+
 set(ADEPT_HEADERS
         adept/cpplapack.h
         include/adept/Active.h
@@ -82,3 +84,4 @@ install(EXPORT adept
         NAMESPACE adept::
         DESTINATION cmake)
 
+add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ set(CMAKE_CXX_STANDARD 14)
 include(CTest)
 
 set(ADEPT_HEADERS
-        adept/cpplapack.h
         include/adept/Active.h
         include/adept/ActiveConstReference.h
         include/adept/ActiveReference.h
@@ -78,7 +77,10 @@ install(TARGETS adept
         ARCHIVE DESTINATION lib
         )
 
-install(FILES ${HEADER_FILES} DESTINATION include/adept)
+install(FILES ${ADEPT_HEADERS} DESTINATION include/adept)
+install(FILES include/adept.h include/adept_arrays.h DESTINATION include)
+
+install(FILES Adept2Config.cmake DESTINATION cmake)
 
 install(EXPORT adept
         NAMESPACE adept::

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,84 @@
+cmake_minimum_required(VERSION 3.6)
+project(Adept2)
+
+set(CMAKE_CXX_STANDARD 14)
+
+set(ADEPT_HEADERS
+        adept/cpplapack.h
+        include/adept/Active.h
+        include/adept/ActiveConstReference.h
+        include/adept/ActiveReference.h
+        include/adept/Allocator.h
+        include/adept/Array.h
+        include/adept/ArrayWrapper.h
+        include/adept/BinaryOperation.h
+        include/adept/Expression.h
+        include/adept/ExpressionSize.h
+        include/adept/FixedArray.h
+        include/adept/IndexedArray.h
+        include/adept/Packet.h
+        include/adept/RangeIndex.h
+        include/adept/ScratchVector.h
+        include/adept/SpecialMatrix.h
+        include/adept/Stack.h
+        include/adept/StackStorage.h
+        include/adept/StackStorageOrig.h
+        include/adept/StackStorageOrigStl.h
+        include/adept/Statement.h
+        include/adept/Storage.h
+        include/adept/UnaryOperation.h
+        include/adept/array_shortcuts.h
+        include/adept/base.h
+        include/adept/contiguous_matrix.h
+        include/adept/cppblas.h
+        include/adept/eval.h
+        include/adept/exception.h
+        include/adept/interp.h
+        include/adept/inv.h
+        include/adept/matmul.h
+        include/adept/noalias.h
+        include/adept/outer_product.h
+        include/adept/reduce.h
+        include/adept/scalar_shortcuts.h
+        include/adept/settings.h
+        include/adept/solve.h
+        include/adept/spread.h
+        include/adept/store_transpose.h
+        include/adept/traits.h
+        include/adept/vector_utilities.h
+        include/adept/where.h
+        )
+
+set(ADEPT_SOURCES
+        adept/Array.cpp
+        adept/Stack.cpp
+        adept/StackStorageOrig.cpp
+        adept/Storage.cpp
+        adept/cppblas.cpp
+        adept/index.cpp
+        adept/inv.cpp
+        adept/jacobian.cpp
+        adept/settings.cpp
+        adept/solve.cpp
+        adept/vector_utilities.cpp
+        )
+
+add_library(adept STATIC ${ADEPT_SOURCES} ${ADEPT_HEADERS})
+add_library(adept::adept ALIAS adept)
+target_include_directories(adept PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+        )
+
+install(TARGETS adept
+        EXPORT adept
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        )
+
+install(FILES ${HEADER_FILES} DESTINATION include/adept)
+
+install(EXPORT adept
+        NAMESPACE adept::
+        DESTINATION cmake)
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,30 @@
+function(add_adept_test TESTNAME)
+    set(TEST_SOURCES
+            algorithm.cpp)
+    set(TEST_HEADERS
+            algorithm.h
+            algorithm_with_and_without_ad.h)
+    add_executable(${TESTNAME} ${TESTNAME}.cpp ${TEST_SOURCES} ${TEST_HEADERS})
+    target_link_libraries(${TESTNAME}
+            PRIVATE
+            adept::adept)
+    enable_testing()
+    add_test(NAME ${TESTNAME} COMMAND ./${TESTNAME})
+endfunction()
+
+add_adept_test(test_adept)
+#add_adept_test(test_adept_with_and_without_ad)
+add_adept_test(test_array_derivatives)
+add_adept_test(test_array_speed)
+add_adept_test(test_arrays)
+add_adept_test(test_checkpoint)
+add_adept_test(test_constructors)
+add_adept_test(test_derivatives)
+add_adept_test(test_fixed_arrays)
+#add_adept_test(test_gsl_interface)
+add_adept_test(test_misc)
+#add_adept_test(test_no_lib)
+#add_adept_test(test_radiances)
+#add_adept_test(test_radiances_array)
+add_adept_test(test_thread_safe)
+add_adept_test(test_thread_safe_arrays)


### PR DESCRIPTION
Useful to for projects that use CMake as their build system.  This exports a cmake target for the adept static library, and installs the adept heads along with a cmake config module.