### PR TITLE
Remove dead code line

### DIFF
--- a/adept/jacobian.cpp
+++ b/adept/jacobian.cpp
@@ -277,7 +277,6 @@ namespace adept {
 	  }
 	}
       }
-      i_independent += MULTIPASS_SIZE;
     } // End of loop over blocks
     
     // Now do the same but for the remaining few columns in the matrix


### PR DESCRIPTION
The removed modification of `i_independent` happens at the end of the scope where `i_independent` is defined, so has no effect.

The line seems to assume that `i_independent` was defined outside of the loop and is maintained in it to be ``MULTIPASS_SIZE * iblock``, which may have been the case at some point, but the code currently defines it in the beginning of the loop's scope to be this value. Note that after removing this line it can be defined with `const` to signify that its value is always such.

(btw, Xcode analyzer pointed me to this issue)