### PR TITLE
Fix warning about ADEPT_THREAD_LOCAL being redefined in Xcode 13.2.1

### DIFF
--- a/include/adept/base.h
+++ b/include/adept/base.h
@@ -245,19 +245,20 @@
 // otherwise it is defined here depending on your compiler
 #ifndef ADEPT_THREAD_LOCAL
   #if defined(__APPLE__)
-    // Thread-local storage often does not work on Mac OS X so by
-    // default we turn it off and provide a blank definition of
-    // ADEPT_THREAD_LOCAL, but then check for its existance using
-    // Clang features
-    #define ADEPT_STACK_THREAD_UNSAFE 1
-    #define ADEPT_THREAD_LOCAL
+    // On macOS we check for its the existance of thread-local-storage
+    // using Clang features.
+    // When unavailable we turn it off and provide a blank definition
+    // of ADEPT_THREAD_LOCAL.
     #ifdef __has_feature
       #if __has_feature(cxx_thread_local)
         // Clang feature check has found that thread_local is
         // available
         #define ADEPT_THREAD_LOCAL thread_local
-        #undef  ADEPT_STACK_THREAD_UNSAFE
       #endif
+    #endif
+    #ifndef ADEPT_THREAD_LOCAL
+      #define ADEPT_STACK_THREAD_UNSAFE 1
+      #define ADEPT_THREAD_LOCAL
     #endif
   #elif defined(ADEPT_CXX11_FEATURES)
     // C++11 has thread_local as part of the language, and should be


### PR DESCRIPTION
I get the following warning when building in Xcode 13.2.1:

<img width="1046" alt="Screen Shot 2022-02-15 at 15 10 01" src="https://user-images.githubusercontent.com/97606/154069445-897c8868-7b0a-4a60-9f03-befedfede210.png">

The change avoids redefining and undefining macros with an `#else` clause.